### PR TITLE
Google does not need access to tabs and active tabs

### DIFF
--- a/chrome-extension/src/public/manifest.json
+++ b/chrome-extension/src/public/manifest.json
@@ -39,9 +39,7 @@
   "devtools_page": "devtools/devtools.html",
   "permissions": [
     "scripting",
-    "storage",
-    "tabs",
-    "activeTab"
+    "storage"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
tabs and active tabs not needed in manifest 